### PR TITLE
use Pack URI for base.xaml

### DIFF
--- a/ColorTheme.xaml
+++ b/ColorTheme.xaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="Base.xaml"></ResourceDictionary>
+        <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml"></ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">


### PR DESCRIPTION
Wox is going to support theme in user appdata folder (Wox-launcher/Wox@dd51efda017cb65067269ea25bccb3cbdc1713ab) , which enables user to keep theme acoss different version, so you cannot rely on relative path to locate the base.xaml any more.

btw, could you rename `src` to other unique name in order to avoid conflicts with other themes